### PR TITLE
Add support for the KVM provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ It also supports running the tsuru instance on AWS:
 $ vagrant up --provider=aws
 ~~~
 
-We also added support for the [KVM provider](https://github.com/adrahon/vagrant-kvm):
+We also added support for the [KVM provider](https://github.com/adrahon/vagrant-kvm),
+you might need the latest [master version of the KVM provider](https://github.com/adrahon/vagrant-kvm/issues/258#issuecomment-68917766) if you get a "random_mac" error.
 
 ~~~bash
 $ vagrant up --provider=kvm

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ It also supports running the tsuru instance on AWS:
 $ vagrant up --provider=aws
 ~~~
 
+We also added support for the [KVM provider](https://github.com/adrahon/vagrant-kvm):
+
+~~~bash
+$ vagrant up --provider=kvm
+~~~
 
 You can also choose between different tsuru versions using the
 `TSURU_BOOTSTRAP` environment variable:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,13 @@ Vagrant.configure("2") do |config|
     override.vm.network :private_network, ip: "192.168.50.4"
   end
 
+  config.vm.provider :kvm do |kvm, override|
+    kvm.memory_size = 1024
+    override.vm.box = "trusty64"
+    override.vm.box_url = "https://vagrant-kvm-boxes-si.s3.amazonaws.com/trusty64-kvm-20140418.box"
+    override.vm.network :private_network, ip: "192.168.50.4"
+  end
+
   config.vm.provider :aws do |aws, override|
     override.vm.box = "dummy"
     override.vm.box_url = "https://raw.githubusercontent.com/mitchellh/vagrant-aws/master/dummy.box"


### PR DESCRIPTION
I'm a huge fan of Qemu-kvm and libvirt so i added support for the [KVM provider](https://github.com/adrahon/vagrant-kvm). 
You might want, to have a look at [issue #258](https://github.com/adrahon/vagrant-kvm/issues/258) it was a show stopper for me. (fix is in comments).